### PR TITLE
Rename unit-test to unit-test-devel

### DIFF
--- a/modules/SpecGenerator.py
+++ b/modules/SpecGenerator.py
@@ -134,8 +134,8 @@ class SpecGenerator:
 	def generateHeaderPrologue(self, project, prefix):
 		self.file.write("# e.g. el6 has ppc64 arch without gcc-go, so EA tag is required\n")
 		self.file.write("ExclusiveArch:  %{?go_arches:%{go_arches}}%{!?go_arches:%{ix86} x86_64 %{arm}}\n")
-		# Once BuildRequires of the compiler is removed from the main package, put it back to unit-test subpackage.
-		# Otherwise %check section can not run 'go test' on tests package in the unit-test subpackage.
+		# Once BuildRequires of the compiler is removed from the main package, put it back to unit-test-devel subpackage.
+		# Otherwise %check section can not run 'go test' on tests package in the unit-test-devel subpackage.
 		self.file.write("# If go_compiler is not set to 1, there is no virtual provide. Use golang instead.\n")
 		self.file.write("BuildRequires:  %{?go_compiler:compiler(go-compiler)}%{!?go_compiler:golang}\n\n")
 
@@ -224,7 +224,7 @@ class SpecGenerator:
 
 	def generateUnitTestHeader(self):
 		self.file.write("%if 0%{?with_unit_test} && 0%{?with_devel}\n")
-		self.file.write("%package unit-test\n")
+		self.file.write("%package unit-test-devel\n")
 		self.file.write("Summary:         Unit tests for %{name} package\n")
 		self.file.write("%if 0%{?with_check}\n")
 		self.file.write("#Here comes all BuildRequires: PACKAGE the unit tests\n#in %%check section need for running\n")
@@ -233,7 +233,7 @@ class SpecGenerator:
 		self.file.write("# test subpackage tests code from devel subpackage\n")
 		self.file.write("Requires:        %{name}-devel = %{version}-%{release}\n")
 		self.file.write("\n")
-		self.file.write("%description unit-test\n")
+		self.file.write("%description unit-test-devel\n")
 		self.file.write("%{summary}\n")
 		self.file.write("\n")
 		self.file.write("This package contains unit tests for project\nproviding packages with %{import_path} prefix.\n")
@@ -296,7 +296,7 @@ class SpecGenerator:
 		self.file.write("# testing files for this project\n")
 		self.file.write("%if 0%{?with_unit_test} && 0%{?with_devel}\n")
 		self.file.write("install -d -p %{buildroot}/%{gopath}/src/%{import_path}/\n")
-		self.file.write("# find all *_test.go files and generate unit-test.file-list\n")
+		self.file.write("# find all *_test.go files and generate unit-test-devel.file-list\n")
 		if godeps_on:
 			self.file.write("for file in $(find . -iname \"*_test.go\" | grep -v \"./Godeps\"); do\n")
 		else:
@@ -304,7 +304,7 @@ class SpecGenerator:
 		self.file.write("    echo \"%%dir %%{gopath}/src/%%{import_path}/$(dirname $file)\" >> devel.file-list\n")
 		self.file.write("    install -d -p %{buildroot}/%{gopath}/src/%{import_path}/$(dirname $file)\n")
 		self.file.write("    cp -pav $file %{buildroot}/%{gopath}/src/%{import_path}/$file\n")
-		self.file.write("    echo \"%%{gopath}/src/%%{import_path}/$file\" >> unit-test.file-list\n")
+		self.file.write("    echo \"%%{gopath}/src/%%{import_path}/$file\" >> unit-test-devel.file-list\n")
 		self.file.write("done\n")
 		self.file.write("%endif\n\n")
 
@@ -388,7 +388,7 @@ class SpecGenerator:
 		self.file.write("%endif\n\n")
 
 		self.file.write("%if 0%{?with_unit_test} && 0%{?with_devel}\n")
-		self.file.write("%files unit-test -f unit-test.file-list\n")
+		self.file.write("%files unit-test-devel -f unit-test-devel.file-list\n")
 
 		if license != []:
 			self.file.write("%%license %s\n" % (" ".join(licenses)))
@@ -440,7 +440,7 @@ class SpecGenerator:
 		self.generateDevelHeader(prj_info, prefix)
 		self.file.write("\n")
 
-		# generate unit-test subpackage
+		# generate unit-test-devel subpackage
 		self.generateUnitTestHeader()
 		self.file.write("\n")
 


### PR DESCRIPTION
rpmlint is complaining that the unit-test package is depending
on a -devel package while it itself is not a -devel package.

Closes #60 
