### PR TITLE
Remove --recursive.

### DIFF
--- a/hack/pull-submodules.sh
+++ b/hack/pull-submodules.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-git submodule update --init --recursive
+git submodule update --init


### PR DESCRIPTION
The .gitmodules of the sub-modules being pulled down into gofed was causing this problem:

``` shell
$ ./hack/prep.sh
Submodule 'third_party/gofed_infra' (https://github.com/gofed/infra) registered for path 'third_party/gofed_infra'
Submodule 'third_party/gofed_lib' (https://github.com/gofed/lib.git) registered for path 'third_party/gofed_lib'
Submodule 'third_party/gofed_resources' (https://github.com/gofed/resources.git) registered for path 'third_party/gofed_resources'
Cloning into 'third_party/gofed_infra'...
remote: Counting objects: 5957, done.
remote: Total 5957 (delta 0), reused 0 (delta 0), pack-reused 5957
Receiving objects: 100% (5957/5957), 7.93 MiB | 3.49 MiB/s, done.
Resolving deltas: 100% (2778/2778), done.
Checking connectivity... done.
Submodule path 'third_party/gofed_infra': checked out '247c2b5cf691a05a81a4b6522f290267f3848708'
Submodule 'third_party/gofed_lib' (https://github.com/gofed/lib) registered for path 'third_party/gofed_lib'
Submodule 'third_party/gofed_resources' (https://github.com/gofed/resources) registered for path 'third_party/gofed_resources'
Cloning into 'third_party/gofed_lib'...
remote: Counting objects: 763, done.
remote: Compressing objects: 100% (5/5), done.
remote: Total 763 (delta 0), reused 0 (delta 0), pack-reused 758
Receiving objects: 100% (763/763), 1.16 MiB | 0 bytes/s, done.
Resolving deltas: 100% (414/414), done.
Checking connectivity... done.
Submodule path 'third_party/gofed_infra/third_party/gofed_lib': checked out '18313c3314cf0a130f03eafc0ed56ba2ef6d9a77'
fatal: no submodule mapping found in .gitmodules for path 'go/symbolsextractor/testdata/example'
Failed to recurse into submodule path 'third_party/gofed_infra/third_party/gofed_lib'
Failed to recurse into submodule path 'third_party/gofed_infra'
Rendering templates
Traceback (most recent call last):
  File "render-templates.py", line 2, in <module>
    from gofed_lib.utils import getScriptDir
ImportError: No module named gofed_lib.utils
Symlink infra to gofed_infra
Making 'resource_client, simplefilestorage, resource_provider, storage' directories under working_directory
```

Removing the `--recursive` flag fixes the issue and lets you use `gofed` from source.
