### PR TITLE
Update README to fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 2. Install python modules
 3. Install packages
 4. Set up gofed
-5. Alias ./hach/gofed.sh
+5. Alias ./hack/gofed.sh
 6. Run gofed
 
 ```sh


### PR DESCRIPTION
Misspelled hack as hach in the early part of the README.

Signed-Off-By: Joe Handzik <joseph.t.handzik@hpe.com>