### PR TITLE
modules/spec.jinja: uncomment the generated gobuild command

### DIFF
--- a/modules/spec.jinja
+++ b/modules/spec.jinja
@@ -228,7 +228,7 @@ export GOPATH=$(pwd){% for path in gopaths %}:$(pwd)/{{ path }}{% endfor %}:%{go
 %endif
 
 {% for package in main["dirs"] -%}
-#%gobuild -o bin/{{ package }} %{import_path}/{{ package }}
+%gobuild -o bin/{{ package }} %{import_path}/{{ package }}
 {% endfor -%}
 {%- endif %}
 %install


### PR DESCRIPTION
The commented gobuild command still runs because the macro is not
escaped with a double percent sign.  It's probably fine to leave
it uncommented by default and rely on the user to either fix or
remove it if the generated command doesn't work.