### PR TITLE
fix(approx-deps): import missing 'os' module

### DIFF
--- a/cmd/approx-deps/approx-deps.py
+++ b/cmd/approx-deps/approx-deps.py
@@ -2,6 +2,7 @@ from gofedinfra.system.models.snapshots.reconstructor import SnapshotReconstruct
 from gofedlib.go.importpath.parserbuilder import ImportPathParserBuilder
 import json
 import optparse
+import os
 import sys
 import logging
 


### PR DESCRIPTION
When we runs `gofed approx-deps --help` command, we gets a "NameError:
name 'os' is not defined" error message. This happened because we didn't
import 'os' module.